### PR TITLE
Make baseUrl for custom API stay in input field

### DIFF
--- a/src/configWindow/components/apiSelector.ts
+++ b/src/configWindow/components/apiSelector.ts
@@ -214,7 +214,7 @@ class ApiSelector extends HTMLElement{
             
         }
         else if(apiConfig.type == "custom"){
-            this.customUrlInput.value = apiConfig.key;
+            this.customUrlInput.value = apiConfig.baseUrl;
             this.customKeyInput.value = apiConfig.key;
             this.customModelInput.value = apiConfig.model;
         }


### PR DESCRIPTION
Right now it empties itself every time you switch away or restart